### PR TITLE
Fix: XSS vulnerability in buildTeam() — replace innerHTML with textContent

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,7 +33,7 @@ const team = [
       <div class="member-card">
         <div class="member-avatar">
           <img src="${m.img}" alt="${m.name}"
-            onerror="this.parentElement.innerHTML='${initials}'">
+            onerror="this.parentElement.textContent='${initials}'">
         </div>
         <div class="member-name">${m.name}</div>
       </div>`;


### PR DESCRIPTION
I'm working on this under NSoC'26

fixes #4 

**Summary:**
Fixes the XSS vulnerability reported in issue #[N] by replacing innerHTML with textContent in the onerror handler of the team member avatar fallback.

**Problem:**
When a team member's image fails to load, the fallback renders their initials using innerHTML:
`onerror="this.parentElement.innerHTML='${initials}'"`
innerHTML parses its input as HTML, meaning special characters in a name (e.g. a single quote in D'souza) can break out of the string context and potentially execute arbitrary JavaScript.

**Fix:**
_before:_ `onerror="this.parentElement.innerHTML='${initials}'"`
_after:_ `onerror="this.parentElement.textContent='${initials}'`

**Why this works?**
textContent writes the value as a raw string — it never parses HTML or JS. Any special characters are rendered literally on screen, making it safe regardless of input content.
