### PR TITLE
feat: Local Scan Histoty

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,35 @@
         </div>
       </div>
 
+      <!-- ── NEW: Scan History ── -->
+      <div class="history-section" id="historySection">
+        <div class="history-top">
+          <div class="history-top-left">
+            <div class="section-tag">Scan History</div>
+            <h2 class="history-title">Previous Scans</h2>
+            <p class="history-sub">Saved locally — persists after page refresh.</p>
+          </div>
+          <button class="clear-history-btn" id="clearHistoryBtn" onclick="clearHistory()">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+              <polyline points="3 6 5 6 21 6"/>
+              <path d="M19 6l-1 14H6L5 6"/>
+              <path d="M10 11v6M14 11v6"/>
+              <path d="M9 6V4h6v2"/>
+            </svg>
+            Clear All
+          </button>
+        </div>
+
+        <div class="history-empty" id="historyEmpty">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" style="opacity:0.3;margin-bottom:10px">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+          </svg>
+          <p>No scans yet. Results will appear here automatically.</p>
+        </div>
+
+        <div class="history-list" id="historyList"></div>
+      </div>
+
       <!-- Features -->
       <div class="features">
         <div class="feature-item">
@@ -109,14 +138,12 @@
           <p class="team-sub">The people who made CyberShield possible</p>
         </div>
 
-        <!-- Toggle arrow button -->
         <button class="team-toggle" id="teamToggle" onclick="toggleTeam()" aria-label="Show team">
           <svg id="toggleIcon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
             <polyline points="6 9 12 15 18 9"/>
           </svg>
         </button>
 
-        <!-- Collapsible grid -->
         <div class="team-grid-wrap" id="teamGridWrap">
           <div class="team-grid" id="teamGrid"></div>
         </div>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ window.addEventListener('load', () => {
     setTimeout(() => {
       loader.style.display = 'none';
       main.classList.remove('hidden');
+      loadHistory(); // ← restore history after page reveals
     }, 500);
   }, 3200);
 });
@@ -22,7 +23,7 @@ const team = [
   { name: "Rahul Sah",     img: "Rahul.jpg"    },
   { name: "Swastika Shaw", img: "Swastika.jpg" },
   { name: "Arpita Roy",    img: "Arpita.jpg"   },
-   {name: "Disha Samanta",     img: "Disha.jpg" },
+  { name: "Disha Samanta", img: "Disha.jpg"    },
 ];
 
 (function buildTeam() {
@@ -40,7 +41,6 @@ const team = [
   }).join('');
 })();
 
-// Team state: default HIDDEN (collapsed), stays hidden on refresh
 let teamOpen = false;
 
 function toggleTeam() {
@@ -131,10 +131,12 @@ async function checkSecurity() {
       updateStats('danger');
       showResult('danger', 'Threat Detected!',
         'This URL is flagged as dangerous. Do not visit it.', url, threats);
+      saveToHistory({ url, type: 'danger', title: 'Threat Detected', threats });
     } else {
       updateStats('safe');
       showResult('safe', 'URL is Safe',
         'No threats detected. Google Safe Browsing found no issues.', url, []);
+      saveToHistory({ url, type: 'safe', title: 'Safe', threats: [] });
     }
 
   } catch (err) {
@@ -142,6 +144,7 @@ async function checkSecurity() {
       `Make sure your backend server is running.<br>
        <small style="color:#334155">Error: ${err.message}</small>`,
       '', []);
+    // Do not save failed/error scans to history
   } finally {
     btn.disabled = false;
   }
@@ -150,3 +153,116 @@ async function checkSecurity() {
 document.getElementById('urlInput').addEventListener('keydown', e => {
   if (e.key === 'Enter') checkSecurity();
 });
+
+
+// ════════════════════════════
+//  SCAN HISTORY  (localStorage)
+// ════════════════════════════
+const HISTORY_KEY = 'cybershield_scan_history';
+const MAX_HISTORY = 50;
+
+function saveToHistory(scan) {
+  let history = getHistory();
+
+  // Remove any previous entry for the same URL (de-duplicate)
+  history = history.filter(item => item.url !== scan.url);
+
+  // Attach timestamp and prepend
+  scan.scannedAt = new Date().toISOString();
+  history.unshift(scan);
+
+  // Cap to MAX_HISTORY
+  if (history.length > MAX_HISTORY) history = history.slice(0, MAX_HISTORY);
+
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+  renderHistory(history);
+}
+
+function getHistory() {
+  try {
+    return JSON.parse(localStorage.getItem(HISTORY_KEY)) || [];
+  } catch {
+    return [];
+  }
+}
+
+function clearHistory() {
+  localStorage.removeItem(HISTORY_KEY);
+  renderHistory([]);
+}
+
+function deleteSingleEntry(url) {
+  const history = getHistory().filter(item => item.url !== url);
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+  renderHistory(history);
+}
+
+function rescanUrl(url) {
+  document.getElementById('urlInput').value = url;
+  document.getElementById('urlInput').scrollIntoView({ behavior: 'smooth', block: 'center' });
+  setTimeout(() => checkSecurity(), 300);
+}
+
+function formatDate(iso) {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit'
+  });
+}
+
+function renderHistory(history) {
+  const list     = document.getElementById('historyList');
+  const emptyEl  = document.getElementById('historyEmpty');
+  const clearBtn = document.getElementById('clearHistoryBtn');
+
+  list.innerHTML = '';
+
+  if (!history || history.length === 0) {
+    emptyEl.style.display = 'flex';
+    clearBtn.style.display = 'none';
+    return;
+  }
+
+  emptyEl.style.display = 'none';
+  clearBtn.style.display = 'flex';
+
+  history.forEach((item, idx) => {
+    const isSafe   = item.type === 'safe';
+    const icon     = isSafe ? '✓' : '✕';
+    const label    = isSafe ? 'Safe' : 'Threat';
+    const tagClass = isSafe ? 'history-tag--safe' : 'history-tag--danger';
+    const threats  = item.threats && item.threats.length
+      ? item.threats.map(t => `<span class="threat-tag" style="font-size:10px;padding:2px 8px">${t}</span>`).join('')
+      : '';
+
+    const card = document.createElement('div');
+    card.className = `history-card history-card--${item.type}`;
+    card.style.animationDelay = `${idx * 35}ms`;
+    card.innerHTML = `
+      <div class="hc-icon-wrap hc-icon-wrap--${item.type}">${icon}</div>
+      <div class="hc-body">
+        <div class="hc-url" title="${item.url}">${item.url}</div>
+        ${threats ? `<div class="hc-threats">${threats}</div>` : ''}
+      </div>
+      <div class="hc-meta">
+        <span class="hc-badge ${tagClass}">${label}</span>
+        <span class="hc-date">${formatDate(item.scannedAt)}</span>
+        <button class="hc-btn hc-btn--rescan" title="Re-scan" onclick="rescanUrl('${item.url.replace(/'/g, "\\'")}')">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+            <polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+          </svg>
+        </button>
+        <button class="hc-btn hc-btn--delete" title="Remove" onclick="deleteSingleEntry('${item.url.replace(/'/g, "\\'")}')">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>`;
+    list.appendChild(card);
+  });
+}
+
+function loadHistory() {
+  renderHistory(getHistory());
+}

--- a/style.css
+++ b/style.css
@@ -503,7 +503,6 @@ input[type="text"]:focus {
   color: #475569;
 }
 
-/* Toggle button */
 .team-toggle {
   display: flex;
   align-items: center;
@@ -519,29 +518,18 @@ input[type="text"]:focus {
   transition: background 0.2s, transform 0.3s;
 }
 
-.team-toggle:hover {
-  background: rgba(0,255,180,0.14);
-}
+.team-toggle:hover { background: rgba(0,255,180,0.14); }
+.team-toggle.open  { transform: rotate(180deg); }
 
-.team-toggle.open {
-  transform: rotate(180deg);
-}
-
-/* Collapsible wrapper */
 .team-grid-wrap {
   overflow: hidden;
   max-height: 0;
-  transition: max-height 0.45s cubic-bezier(0.4, 0, 0.2, 1),
-              opacity 0.35s ease;
+  transition: max-height 0.45s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.35s ease;
   opacity: 0;
 }
 
-.team-grid-wrap.open {
-  max-height: 400px;
-  opacity: 1;
-}
+.team-grid-wrap.open { max-height: 400px; opacity: 1; }
 
-/* Grid */
 .team-grid {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
@@ -583,15 +571,9 @@ input[type="text"]:focus {
   transition: border-color 0.2s;
 }
 
-.member-card:hover .member-avatar {
-  border-color: #00ffb4;
-}
+.member-card:hover .member-avatar { border-color: #00ffb4; }
 
-.member-avatar img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
+.member-avatar img { width: 100%; height: 100%; object-fit: cover; }
 
 .member-name {
   font-size: 13px;
@@ -609,12 +591,199 @@ input[type="text"]:focus {
   color: #334155;
 }
 
+/* ════════════════════════════
+   SCAN HISTORY  ← NEW
+════════════════════════════ */
+.history-section {
+  margin-top: 32px;
+  padding: 28px;
+  background: rgba(255,255,255,0.02);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 20px;
+}
+
+.history-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.history-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #e2e8f0;
+  letter-spacing: -0.02em;
+  margin-bottom: 4px;
+}
+
+.history-sub {
+  font-size: 12px;
+  color: #475569;
+}
+
+.clear-history-btn {
+  display: none;            /* shown by JS when history exists */
+  align-items: center;
+  gap: 6px;
+  background: rgba(255,50,50,0.07);
+  border: 1px solid rgba(255,50,50,0.2);
+  border-radius: 10px;
+  padding: 8px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #f87171;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.clear-history-btn:hover {
+  background: rgba(255,50,50,0.14);
+  border-color: rgba(255,50,50,0.4);
+}
+
+/* Empty state */
+.history-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 36px 20px;
+  color: #334155;
+  font-size: 13px;
+  text-align: center;
+  gap: 4px;
+}
+
+/* History list */
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Individual history card */
+.history-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.06);
+  background: rgba(255,255,255,0.02);
+  animation: slideUp 0.3s ease both;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.history-card:hover { background: rgba(255,255,255,0.04); }
+
+.history-card--safe   { border-left: 3px solid rgba(0,255,100,0.4); }
+.history-card--danger { border-left: 3px solid rgba(255,50,50,0.45); }
+
+/* Status icon circle */
+.hc-icon-wrap {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.hc-icon-wrap--safe   { background: rgba(0,255,100,0.1);  color: #4ade80; }
+.hc-icon-wrap--danger { background: rgba(255,50,50,0.1);   color: #f87171; }
+
+/* URL + threats */
+.hc-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.hc-url {
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  color: #94a3b8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hc-threats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 5px;
+}
+
+/* Right-side meta */
+.hc-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.hc-badge {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border-radius: 100px;
+  padding: 3px 10px;
+  border: 1px solid;
+}
+
+.history-tag--safe   { color: #4ade80; border-color: rgba(0,255,100,0.3); background: rgba(0,255,100,0.07); }
+.history-tag--danger { color: #f87171; border-color: rgba(255,50,50,0.3); background: rgba(255,50,50,0.07); }
+
+.hc-date {
+  font-size: 11px;
+  color: #334155;
+  white-space: nowrap;
+}
+
+/* Icon action buttons */
+.hc-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: transparent;
+  color: #475569;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+}
+
+.hc-btn--rescan:hover {
+  background: rgba(0,255,180,0.1);
+  border-color: rgba(0,255,180,0.3);
+  color: #00ffb4;
+}
+
+.hc-btn--delete:hover {
+  background: rgba(255,50,50,0.1);
+  border-color: rgba(255,50,50,0.3);
+  color: #f87171;
+}
+
 /* ── Responsive ── */
 @media (max-width: 600px) {
   .input-row  { flex-direction: column; }
   .stats-row  { grid-template-columns: repeat(2, 1fr); }
   .team-grid  { grid-template-columns: repeat(3, 1fr); }
   .member-avatar { width: 70px; height: 70px; font-size: 18px; }
+  .hc-date    { display: none; }
+  .hc-url     { font-size: 11px; }
 }
 
 @media (max-width: 380px) {


### PR DESCRIPTION
## 🚀 Summary

This PR introduces a client-side scan history feature using the browser's `localStorage`. Each successful scan is automatically saved and displayed as a history card, allowing users to revisit previous scans even after refreshing or reopening the app.

---

## ✨ Features

* Persist scan results (`safe` and `danger`) using `localStorage` (`cybershield_scan_history`)
* Automatically load and render history on page load
* De-duplicate entries: repeated scans of the same URL update the existing record
* Per-entry actions:

  * ↻ Re-scan URL
  * ✕ Delete individual entry
* "Clear All" button to remove entire history (hidden when empty)
* History capped at 50 entries to prevent excessive storage usage
* Only successful API responses are stored (failed scans excluded)

---

## 📂 Files Changed

* `script.js`

  * Added history management functions
  * Integrated history saving into `checkSecurity()`
* `index.html`

  * Added history section below stats row
* `style.css`

  * Added styles for history UI components

---

## ✅ Acceptance Criteria

* [x] Scan results persist after page refresh
* [x] History renders correctly on load
* [x] No duplicate entries for the same URL
* [x] UI matches existing theme and design
* [x] Fully client-side implementation (no backend changes)

---

## 🧪 Testing Steps

1. Scan a URL → result + history entry appears
2. Refresh page → history persists
3. Scan same URL again → entry updates (no duplicate)
4. Open DevTools → Application → Local Storage → verify `cybershield_scan_history`
5. Click ✕ → removes a single entry
6. Click "Clear All" → clears entire history
7. Click ↻ → re-fills input and triggers new scan

---

## 📌 Notes

* Designed to be lightweight and performant
* Ensures a better user experience without introducing backend complexity

---

## 🔗 Related Issue

Closes #1 
