### PR TITLE
feat: improve accessibility for results and statistics (#24)

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,9 +42,9 @@
       <div class="scanner-card">
 
         <!-- Tab switcher -->
-        <div class="scan-tabs">
-          <button class="scan-tab active" id="tabSingle" onclick="switchTab('single')">Single URL</button>
-          <button class="scan-tab" id="tabBulk" onclick="switchTab('bulk')">Bulk Scan</button>
+        <div class="scan-tabs" role="tablist">
+          <button class="scan-tab active" id="tabSingle" role="tab" aria-selected="true" onclick="switchTab('single')">Single URL</button>
+          <button class="scan-tab" id="tabBulk" role="tab" aria-selected="false" onclick="switchTab('bulk')">Bulk Scan</button>
         </div>
 
         <!-- Single URL panel -->
@@ -55,7 +55,7 @@
               <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
               <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
             </svg>
-            <input type="text" id="urlInput" placeholder="https://example.com" autocomplete="off" spellcheck="false">
+            <input type="text" id="urlInput" placeholder="https://example.com" autocomplete="off" spellcheck="false" aria-label="Enter URL to scan">
           </div>
           <button class="scan-btn" id="scanBtn" onclick="checkSecurity()">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
@@ -67,13 +67,13 @@
 
         <div class="examples">
           <span class="examples-label">Try:</span>
-          <span class="example-chip" onclick="fillExample('https://google.com')">google.com</span>
-          <span class="example-chip" onclick="fillExample('https://github.com')">github.com</span>
-          <span class="example-chip" onclick="fillExample('http://testsafebrowsing.appspot.com/s/phishing.html')">phishing test</span>
-          <span class="example-chip" onclick="fillExample('http://testsafebrowsing.appspot.com/s/malware.html')">malware test</span>
+          <span class="example-chip" role="button" tabindex="0" onclick="fillExample('https://google.com')" onkeydown="if(event.key==='Enter')fillExample('https://google.com')">google.com</span>
+          <span class="example-chip" role="button" tabindex="0" onclick="fillExample('https://github.com')" onkeydown="if(event.key==='Enter')fillExample('https://github.com')">github.com</span>
+          <span class="example-chip" role="button" tabindex="0" onclick="fillExample('http://testsafebrowsing.appspot.com/s/phishing.html')" onkeydown="if(event.key==='Enter')fillExample('http://testsafebrowsing.appspot.com/s/phishing.html')">phishing test</span>
+          <span class="example-chip" role="button" tabindex="0" onclick="fillExample('http://testsafebrowsing.appspot.com/s/malware.html')" onkeydown="if(event.key==='Enter')fillExample('http://testsafebrowsing.appspot.com/s/malware.html')">malware test</span>
         </div>
 
-        <div id="result"></div>
+        <div id="result" aria-live="polite" aria-atomic="true"></div>
         </div>
 
         <!-- Bulk URL panel -->
@@ -92,29 +92,29 @@
             </svg>
             Scan All URLs
           </button>
-          <div id="bulkProgress" class="bulk-progress hidden">
+          <div id="bulkProgress" class="bulk-progress hidden" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
             <div class="bulk-progress-info">
               <span id="bulkProgressLabel">Scanning…</span>
               <span id="bulkProgressText">0 / 0</span>
             </div>
             <div class="bulk-progress-bar"><div class="bulk-progress-fill" id="bulkProgressFill"></div></div>
           </div>
-          <div id="bulkResult"></div>
+          <div id="bulkResult" aria-live="polite" aria-atomic="true"></div>
         </div>
 
       </div>
 
       <!-- Stats -->
       <div class="stats-row">
-        <div class="stat-card">
+        <div class="stat-card" aria-live="polite" aria-atomic="true">
           <div class="stat-num" id="totalScans">0</div>
           <div class="stat-label">URLs Scanned</div>
         </div>
-        <div class="stat-card">
+        <div class="stat-card" aria-live="polite" aria-atomic="true">
           <div class="stat-num" id="safeCount">0</div>
           <div class="stat-label">Safe</div>
         </div>
-        <div class="stat-card">
+        <div class="stat-card" aria-live="polite" aria-atomic="true">
           <div class="stat-num" id="dangerCount">0</div>
           <div class="stat-label">Threats Blocked</div>
         </div>

--- a/script.js
+++ b/script.js
@@ -231,8 +231,13 @@ function switchTab(tab) {
   const isBulk = tab === 'bulk';
   document.getElementById('panelSingle').classList.toggle('hidden', isBulk);
   document.getElementById('panelBulk').classList.toggle('hidden', !isBulk);
-  document.getElementById('tabSingle').classList.toggle('active', !isBulk);
-  document.getElementById('tabBulk').classList.toggle('active', isBulk);
+  
+  const tabS = document.getElementById('tabSingle');
+  const tabB = document.getElementById('tabBulk');
+  tabS.classList.toggle('active', !isBulk);
+  tabS.setAttribute('aria-selected', !isBulk);
+  tabB.classList.toggle('active', isBulk);
+  tabB.setAttribute('aria-selected', isBulk);
 }
 
 function updateBulkCount() {
@@ -270,6 +275,7 @@ async function runBulkScan() {
 
   btn.disabled = true;
   progress.classList.remove('hidden');
+  progress.setAttribute('aria-valuenow', '0');
   fill.style.width = '0%';
   progText.textContent = `0 / ${urls.length}`;
   progLabel.textContent = 'Scanning…';
@@ -308,6 +314,7 @@ async function runBulkScan() {
         done++;
         const pct = Math.round((done / urls.length) * 100);
         fill.style.width = pct + '%';
+        progress.setAttribute('aria-valuenow', pct);
         progText.textContent = `${done} / ${urls.length}`;
         updateBtrRow(i, result);
       })
@@ -325,6 +332,7 @@ async function runBulkScan() {
 
   progLabel.textContent = 'Complete';
   fill.style.width = '100%';
+  progress.setAttribute('aria-valuenow', '100');
 
   const summary = document.createElement('div');
   summary.className = 'bulk-summary';


### PR DESCRIPTION
I've implemented the accessibility improvements requested in #24 to make CyberShield more inclusive for users relying on screen readers.

Changes:
Live Regions: Added aria-live="polite" and aria-atomic="true" to scan result containers (#result, #bulkResult) so scan outcomes are automatically announced.
Dynamic Stats: Added live region support to statistics cards so that counter updates (URLs scanned, threats blocked, etc.) are voiced in real-time with context.
Improved Forms: Added an aria-label to the main URL input field to clarify its purpose for assistive technology.
Navigation & Progress:
Added ARIA roles (tablist, tab) and managed aria-selected states for the scan mode switcher.
Added role="progressbar" with dynamic aria-valuenow updates for the bulk scanner.
Keyboard Support: Added tabindex="0" and Enter key support for the example URL chips, ensuring they are fully navigable by keyboard.
Verified these changes on a local environment and the UI feels much more responsive to assistive tools now. Ready for review!