### PR TITLE
feat: add rate limiting to prevent API abuse (closes #13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.6",
+        "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.4.1",
         "node-fetch": "^2.7.0"
       }
     },
@@ -172,6 +174,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -287,6 +301,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/finalhandler": {
@@ -451,6 +483,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "type": "commonjs",
   "dependencies": {
     "cors": "^2.8.6",
+    "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.4.1",
     "node-fetch": "^2.7.0"
   }
 }

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 //  LOADER
 
-window.addEventListener('load', () => {
+document.addEventListener('DOMContentLoaded', () => {   // ← fix: was window.addEventListener('load')
   setTimeout(() => {
     const loader = document.getElementById('loader');
     const main   = document.getElementById('mainPage');
@@ -20,7 +20,7 @@ const team = [
   { name: "Rahul Sah",     img: "Rahul.jpg"    },
   { name: "Swastika Shaw", img: "Swastika.jpg" },
   { name: "Arpita Roy",    img: "Arpita.jpg"   },
-   {name: "Disha Samanta",     img: "Disha.jpg" },
+  { name: "Disha Samanta", img: "Disha.jpg"    },
 ];
 
 (function buildTeam() {
@@ -104,6 +104,7 @@ async function checkSecurity() {
     return;
   }
 
+
   let url = input;
   if (!url.startsWith('http://') && !url.startsWith('https://')) {
     url = 'https://' + url;
@@ -114,11 +115,23 @@ async function checkSecurity() {
   showResult('loading', 'Scanning...', 'Checking against threat databases. Please wait.', url, []);
 
   try {
-    const response = await fetch('https://cybershield-sxz0.onrender.com/check', {
-      method: 'POST',
+const BASE_URL = (window.location.hostname === 'localhost' || window.location.hostname === '')
+  ? 'http://localhost:3000'
+  : 'https://cybershield-sxz0.onrender.com';
+const response = await fetch(`${BASE_URL}/check`, {
+        method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url })
     });
+
+    // ← fix: handle rate limit response from backend
+    if (response.status === 429) {
+      const data = await response.json();
+      const wait = data.retryAfter ? ` Try again in ${data.retryAfter}s.` : '';
+      showResult('error', 'Slow Down!',
+        `You've hit the scan limit (10 per minute).${wait}`, '', []);
+      return;
+    }
 
     if (!response.ok) throw new Error('Server error ' + response.status);
     const data = await response.json();

--- a/server.js
+++ b/server.js
@@ -1,36 +1,53 @@
 const express = require("express");
+
 const cors = require("cors");
-const dotenv = require("dotenv")
+const dotenv = require("dotenv");
+const rateLimit = require("express-rate-limit");  // ← added
+
 dotenv.config()
-
 const app = express();
+app.set('trust proxy', 1); 
 const PORT = process.env.PORT || 3000;
-
 
 app.use(cors({
   origin: "*",
   methods: ["GET", "POST"],
   allowedHeaders: ["Content-Type"]
 }));
-
 app.use(express.json());
 
+const API_KEY = process.env.API_KEY;
 
-const  API_KEY = process.env.API_KEY;
-
+// ── Rate Limiter ─────────────────────────────────────────────────────────────
+const scanLimiter = rateLimit({                   // ← added
+  windowMs: 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    console.warn(`[RATE LIMIT] IP ${req.ip} exceeded scan limit`);
+    res.status(429).json({
+      error: "Too many requests",
+      message: "You have exceeded the limit of 10 scans per minute. Please wait before trying again.",
+      retryAfter: Math.ceil(req.rateLimit.resetTime / 1000 - Date.now() / 1000)
+    });
+  }
+});
 
 app.get("/", (req, res) => {
   res.json({ status: "CyberShield backend running", port: PORT });
 });
 
-app.post("/check", async (req, res) => {
+app.post("/check", scanLimiter, async (req, res) => { 
+  
+  console.log(`[DEBUG] req.ip = ${req.ip}`);          // ← add this
+  console.log(`[DEBUG] x-forwarded-for = ${req.headers['x-forwarded-for']}`); // ← and this
+  
   const userUrl = req.body.url;
-
   if (!userUrl) {
     return res.status(400).json({ error: "No URL provided" });
   }
 
-  
   try {
     new URL(userUrl);
   } catch {
@@ -58,17 +75,28 @@ app.post("/check", async (req, res) => {
   };
 
   try {
-    const response = await fetch(
-      `https://safebrowsing.googleapis.com/v4/threatMatches:find?key=${API_KEY}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(requestBody)
-      }
-    );
+  
+
+const response = await fetch(
+  `https://safebrowsing.googleapis.com/v4/threatMatches:find?key=${API_KEY}`,
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(requestBody)
+  }
+);
 
     if (!response.ok) {
       const errText = await response.text();
+
+      if (response.status === 429) {                // ← added: surface Google quota errors
+        console.error("[API QUOTA] Google Safe Browsing quota exceeded");
+        return res.status(503).json({
+          error: "API quota exceeded",
+          message: "The Google Safe Browsing quota has been reached. Please try again later."
+        });
+      }
+
       console.error(`[API ERROR] Status ${response.status}:`, errText);
       return res.status(502).json({
         error: `Google API error: ${response.status}`,
@@ -89,5 +117,6 @@ app.post("/check", async (req, res) => {
 app.listen(PORT, () => {
   console.log(`\n🛡️  CyberShield Backend`);
   console.log(`🚀  Running at http://localhost:${PORT}`);
-  console.log(`📡  POST /check to scan a URL\n`);
+  console.log(`📡  POST /check to scan a URL`);
+  console.log(`🔒  Rate limit: 10 requests / minute / IP\n`);  // ← added
 });


### PR DESCRIPTION
## What this PR does
Implements rate limiting on the `/check` endpoint using `express-rate-limit` to prevent API abuse and Google Safe Browsing quota exhaustion.

## Changes
- Added `express-rate-limit` middleware (10 requests/min/IP)
- Returns structured 429 JSON response with `retryAfter` field
- Frontend handles 429 and shows "Slow Down!" message to user
- Added `trust proxy` for correct IP detection on Render deployment
- Fixed `BASE_URL` detection to work when opening HTML directly as a file

## How to test
1. Run `node server.js` locally
2. Click Scan URL more than 10 times rapidly
3. After the 10th scan, the "Slow Down!" message appears
4. Wait 1 minute — scanning resumes normally

## Fixes #13