### PR TITLE
fix: disable url input during scan

### DIFF
--- a/script.js
+++ b/script.js
@@ -115,6 +115,7 @@ async function checkSecurity() {
 
   const btn = document.getElementById('scanBtn');
   btn.disabled = true;
+  document.getElementById('urlInput').disabled = true;
   showResult('loading', 'Scanning...', 'Checking against threat databases. Please wait.', url, []);
 
   var i=arr.length;
@@ -169,6 +170,7 @@ const response = await fetch(`${BASE_URL}/check`, {
       '', []);
   } finally {
     btn.disabled = false;
+    document.getElementById('urlInput').disabled = false; 
   }
 }
 


### PR DESCRIPTION
## Fix: Disable URL input during scan

Closes issue: #34 

### What this fixes
The loading state was already partially implemented (spinner, `Scanning...` message, and button disable were all in place). The only missing piece was that `#urlInput` was never disabled during a scan — letting users edit the URL mid-request, causing the result to mismatch what's shown in the input.

### Changes
Two lines added to `checkSecurity()` in `script.js`:
- `urlInput.disabled = true` after `btn.disabled = true` on scan start
- `urlInput.disabled = false` in the `finally` block on scan end

### Testing
1. Enter a URL and click **Scan URL**
2. Verify the input is non-editable during scanning
3. Verify it re-enables after result or error

###Screenshot:
<img width="1366" height="768" alt="Screenshot (529)" src="https://github.com/user-attachments/assets/431c610d-7d59-4249-860f-0b67ca3e3646" />
