### PR TITLE
chore: add node standard ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 logs
 *.log
 npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
 
 # Environment variables
 .env
@@ -19,3 +22,25 @@ npm-debug.log*
 .cache/
 dist/
 build/
+
+# Testing
+coverage/
+.nyc_output/
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDEs and Editors
+.vscode/
+.idea/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?


### PR DESCRIPTION
### Description
This PR addresses the tracking issue by updating the `.gitignore` file with comprehensive, industry-standard Node.js ignore patterns. It introduces robust exclusions for development log files (`yarn-error.log*`, `pnpm-debug.log*`), test coverage outputs (`coverage/`), IDE system files (`.vscode/`, `.idea/`), and local OS artifacts. This prevents redundant metadata and local build files from cluttering the repository tracking history.

### Context Links
Closes #114

### Checklist
- [x] Retained existing project-specific ignore definitions.
- [x] Verified block formatting with clear comment headers.
- [x] Confirmed direct merge capability with main branch.