### PR TITLE
feat: add loading animation during URL scanning

### DIFF
--- a/script.js
+++ b/script.js
@@ -338,6 +338,8 @@ function showResult(type, title, desc, url, threats) {
         ${
           type === 'loading'
             ? '<div class="spinner"></div>'
+            : type === 'scan-loading'
+            ? ''
             : `<span>${icons[type]}</span>`
         }
 
@@ -437,15 +439,54 @@ async function checkSecurity() {
 
   btn.disabled = true;
 
-  // Loading State
+  // Loading State — enhanced scan animation
 
-  showResult(
-    'loading',
-    'Scanning...',
-    'Checking against threat databases. Please wait.',
-    url,
-    []
-  );
+  document.getElementById('result').innerHTML = `
+    <div class="result-card loading">
+      <div class="result-body">
+        <div class="scan-loading">
+          <div class="scan-shield-wrap">
+            <div class="scan-shield-ring-outer"></div>
+            <div class="scan-shield-ring"></div>
+            <div class="scan-shield-icon">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent-1)" stroke-width="1.8">
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+              </svg>
+            </div>
+          </div>
+          <div>
+            <div class="result-title" style="text-align:center;">Scanning URL...</div>
+            <div class="result-url" style="text-align:center;margin-top:8px;">${url}</div>
+          </div>
+          <div class="scan-progress-wrap">
+            <div class="scan-progress-bar">
+              <div class="scan-progress-fill"></div>
+            </div>
+            <div class="scan-status-text">
+              <span class="scan-status-step">Checking threat databases...</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>`;
+
+  // Animate status text steps
+  const statusEl = document.querySelector('.scan-status-step');
+  const steps = [
+    'Connecting to Safe Browsing API...',
+    'Analyzing URL patterns...',
+    'Checking threat databases...',
+    'Finalizing results...'
+  ];
+  let stepIndex = 0;
+  const stepTimer = setInterval(() => {
+    stepIndex++;
+    if (stepIndex < steps.length && statusEl) {
+      statusEl.textContent = steps[stepIndex];
+    } else {
+      clearInterval(stepTimer);
+    }
+  }, 800);
 
   try {
     const apiHost = (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')

--- a/style.css
+++ b/style.css
@@ -726,6 +726,112 @@ input[type="text"].input-error {
   animation: spin 0.8s linear infinite;
 }
 
+/* ── Scan Loading Animation ── */
+.scan-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding: 16px 0;
+}
+
+.scan-shield-wrap {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scan-shield-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 3px solid transparent;
+  border-top-color: var(--accent-1);
+  border-right-color: rgba(var(--accent-1-rgb), 0.3);
+  animation: spin 1s linear infinite;
+}
+
+.scan-shield-ring-outer {
+  position: absolute;
+  inset: -8px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  border-bottom-color: var(--accent-2);
+  border-left-color: rgba(0, 191, 255, 0.2);
+  animation: spin 1.5s linear infinite reverse;
+}
+
+.scan-shield-icon {
+  width: 48px;
+  height: 48px;
+  background: rgba(var(--accent-1-rgb), 0.08);
+  border: 1px solid rgba(var(--accent-1-rgb), 0.2);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: shieldPulse 2s ease-in-out infinite;
+}
+
+@keyframes shieldPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(var(--accent-1-rgb), 0.2); }
+  50%      { box-shadow: 0 0 0 10px rgba(var(--accent-1-rgb), 0); }
+}
+
+.scan-progress-wrap {
+  width: 100%;
+  max-width: 280px;
+}
+
+.scan-progress-bar {
+  height: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.light-mode .scan-progress-bar {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.scan-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent-1), var(--accent-2));
+  border-radius: 3px;
+  animation: scanProgress 2.5s ease-in-out infinite;
+}
+
+@keyframes scanProgress {
+  0%   { width: 0%; }
+  50%  { width: 70%; }
+  80%  { width: 90%; }
+  100% { width: 100%; }
+}
+
+.scan-status-text {
+  font-size: 13px;
+  color: #64748b;
+  text-align: center;
+  margin-top: 6px;
+  letter-spacing: 0.02em;
+}
+
+.scan-status-step {
+  font-size: 12px;
+  color: var(--accent-1);
+  font-weight: 600;
+  animation: statusPulse 1.5s ease-in-out infinite;
+}
+
+@keyframes statusPulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.5; }
+}
+
 @keyframes spin { to { transform: rotate(360deg); } }
 
 /* ── Stats ── */


### PR DESCRIPTION
Before: A basic small spinner (22px circle) with plain "Scanning..." text during URL scan.

<img width="468" height="416" alt="Screenshot 2026-06-08 at 12 02 16 AM" src="https://github.com/user-attachments/assets/09697815-b561-4957-8217-16360f462c4c" />

  
  After: An enhanced, branded loading animation with:                                       
  - Shield icon with pulse effect (matches CyberShield branding)                          
  - Double rotating rings (inner + outer, spinning in opposite directions)                  
  - Animated progress bar with gradient (accent-1 to accent-2)            
  - Step-by-step status text that cycles through:                                           
    a. "Connecting to Safe Browsing API..."                                                 
    b. "Analyzing URL patterns..."                                                          
    c. "Checking threat databases..."                                                       
    d. "Finalizing results..." 
    
   
<img width="521" height="330" alt="Screenshot 2026-06-08 at 12 03 17 AM" src="https://github.com/user-attachments/assets/97e55b5a-d09a-469d-9da5-325815446e8d" />
