### PR TITLE
feat: Implement client-side URL validation

### DIFF
--- a/script.js
+++ b/script.js
@@ -107,7 +107,25 @@ let dangerCount = 0;
 function isValidUrl(urlString) {
 
   try {
-    new URL(urlString);
+    const urlObj = new URL(urlString);
+    const hostname = urlObj.hostname;
+
+    // To allow local testing
+    if (hostname === 'localhost' || hostname === '127.0.0.1') {
+      return true;
+    }
+
+    const parts = hostname.split('.');
+    if (parts.length < 2) {
+      return false;
+    }
+
+    const tld = parts[parts.length - 1];
+    // TLD must be at least 2 chars & consist of only letters
+    if (tld.length < 2 || !/^[a-zA-Z]+$/.test(tld)) {
+      return false;
+    }
+
     return true;
   } catch (e) {
     return false;
@@ -138,6 +156,15 @@ function formatAndValidateUrl(input) {
     !url.startsWith('https://')
   ) {
     url = 'https://' + url;
+  }
+
+  // Validate URL length
+  if (url.length > 2048) {
+    return {
+      valid: false,
+      error: 'URL exceeds maximum length of 2048 characters.',
+      url: null
+    };
   }
 
   if (!isValidUrl(url)) {
@@ -261,7 +288,7 @@ function calculateRiskScore(url, isThreat) {
       score += 10;
       breakdown.push({ text: 'Excessive subdomains used', type: 'warning' });
     } else {
-       breakdown.push({ text: 'Domain structure appears normal', type: 'safe' });
+      breakdown.push({ text: 'Domain structure appears normal', type: 'safe' });
     }
   } catch (e) {
     score += 20;
@@ -270,8 +297,8 @@ function calculateRiskScore(url, isThreat) {
 
   score = Math.min(100, score);
 
-  let confidence = isThreat ? 99 : 88; 
-  if (!isThreat && score > 20) confidence -= 12; 
+  let confidence = isThreat ? 99 : 88;
+  if (!isThreat && score > 20) confidence -= 12;
 
   return { score, confidence, breakdown };
 }
@@ -291,7 +318,7 @@ function showResult(type, title, desc, url, threats) {
 
   if ((type === 'safe' || type === 'danger') && url) {
     riskData = calculateRiskScore(url, isThreat);
-    
+
     let meterColor = 'var(--accent-1)';
     if (riskData.score > 30) meterColor = '#fbbf24';
     if (riskData.score > 60) meterColor = '#f87171';
@@ -335,13 +362,12 @@ function showResult(type, title, desc, url, threats) {
 
       <div class="result-icon">
 
-        ${
-          type === 'loading'
-            ? '<div class="spinner"></div>'
-            : type === 'scan-loading'
-            ? ''
-            : `<span>${icons[type]}</span>`
-        }
+        ${type === 'loading'
+      ? '<div class="spinner"></div>'
+      : type === 'scan-loading'
+        ? ''
+        : `<span>${icons[type]}</span>`
+    }
 
       </div>
 
@@ -350,9 +376,9 @@ function showResult(type, title, desc, url, threats) {
         <div class="result-desc">${desc}</div>
         ${url ? `<div class="result-url">${url}</div>` : ''}
         ${threats && threats.length
-          ? `<div class="threat-tags">${threats.map(t =>
-              `<span class="threat-tag">${t}</span>`).join('')}</div>`
-          : ''}
+      ? `<div class="threat-tags">${threats.map(t =>
+        `<span class="threat-tag">${t}</span>`).join('')}</div>`
+      : ''}
         ${(type === 'safe' || type === 'danger') ? `
           <div class="export-btns">
             <button onclick="downloadPDF()" class="export-btn export-btn-pdf">⬇ Download PDF</button>


### PR DESCRIPTION
## Related Issue
Closes #121 

## Summary
Introduced robust client-side validation to check URL syntax and length before initiating a security scan. This reduces unnecessary API traffic to the backend for invalid inputs and provides immediate, user-friendly feedback.

## Changes Made
- **TLD Validation in `isValidUrl`:** Enhanced `isValidUrl` to split hostnames and ensure a valid Top-Level Domain (TLD) suffix of at least 2 letters (e.g. `domain.tld`). Made an exception to permit `localhost` and `127.0.0.1` for local developer testing.
- **Length Constraint check:** Introduced a client-side check verifying the URL does not exceed 2048 characters
- **Halt Invalid Scans:** Ensured scanning operations and backend API requests do not trigger if input validation fails.

## Testing
- Verified locally that standard URLs (e.g. `google.com`) format and scan correctly.
- Verified that local test URLs (e.g. `localhost`) bypass TLD checks.
- Verified that invalid URLs (e.g. `http://invalidtld`, `http://t.x`, or missing domains) show the "Invalid URL format" error and halt immediately.
- Verified that excessively long URLs (> 2048 chars) fail client-side with a clear length error message.

## Screenshots
**Before**:
<img width="1177" height="531" alt="image" src="https://github.com/user-attachments/assets/996fd7f4-6abb-4c7a-ad5c-52c169056cbd" />
<img width="1157" height="473" alt="image" src="https://github.com/user-attachments/assets/0681bd46-7237-4385-9794-688f1e22b42f" />

**After**:
<img width="1105" height="347" alt="image" src="https://github.com/user-attachments/assets/03b2e660-ccb9-4ab0-9516-0dbcc3ec357b" />
<img width="1150" height="420" alt="image" src="https://github.com/user-attachments/assets/ba35a05d-32c5-4dec-8b0e-baab97843c54" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
