### PR TITLE
feat: add shareable URL scan reports with public summary page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -265,7 +265,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",

--- a/script.js
+++ b/script.js
@@ -40,6 +40,7 @@ const team = [
 (function buildTeam() {
 
   const grid = document.getElementById('teamGrid');
+  if (!grid) return;
 
   grid.innerHTML = team.map(m => {
 
@@ -548,6 +549,12 @@ function showResult(type, title, desc, url, threats) {
           <div class="export-btns">
             <button type="button" onclick="downloadPDF()" class="export-btn export-btn-pdf" aria-label="Download scan report as PDF">⬇ Download PDF</button>
             <button type="button" onclick="downloadImage()" class="export-btn export-btn-img" aria-label="Download scan report as image">⬇ Download Image</button>
+            <button type="button"
+  onclick="shareReport()"
+  class="export-btn"
+  aria-label="Share scan report">
+  🔗 Share Report
+</button>
           </div>` : ''}
       </div>
     </div>`;
@@ -803,12 +810,18 @@ async function checkSecurity() {
       }
     }
 
-  } catch (err) {
-    showResult('error', 'Scan Error',
-      `An unexpected error occurred.<br>
-       <small style="color:#334155">Error: ${err.message}</small>`,
-      '', []);
-  } finally {
+} catch (err) {
+
+  showResult(
+    'error',
+    'Scan Error',
+    `An unexpected error occurred.<br>
+     <small style="color:#334155">Error: ${err.message}</small>`,
+    '',
+    []
+  );
+
+} finally {
     btn.disabled = false;
     btn.removeAttribute('aria-busy');
     btn.setAttribute('aria-label', 'Scan the entered URL for security threats');
@@ -914,3 +927,77 @@ async function downloadPDF() {
   }
 
 })();
+
+// ─────────────────────────────
+// SHARE REPORT
+// ─────────────────────────────
+
+async function shareReport() {
+
+  try {
+
+    const resultUrl =
+      document.querySelector('.result-url')?.textContent;
+
+    const resultTitle =
+      document.querySelector('.result-title')?.textContent;
+
+    const threatTags =
+      [...document.querySelectorAll('.threat-tag')]
+        .map(tag => tag.textContent);
+
+    const riskScore =
+      document.getElementById('animated-score')?.textContent || 0;
+
+    if (!resultUrl || !resultTitle) {
+      alert("No scan report available to share.");
+      return;
+    }
+
+    const apiHost =
+      (window.location.hostname === 'localhost' ||
+       window.location.hostname === '127.0.0.1')
+      ? 'http://localhost:3002'
+      : 'https://cybershield-sxz0.onrender.com';
+
+    const response = await fetch(`${apiHost}/share`, {
+
+      method: 'POST',
+
+      headers: {
+        'Content-Type': 'application/json'
+      },
+
+      body: JSON.stringify({
+        url: resultUrl,
+        resultType: resultTitle,
+        threats: threatTags,
+        riskScore
+      })
+
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.error || "Failed to generate share link");
+    }
+
+    // Copy link automatically
+    await navigator.clipboard.writeText(data.shareUrl);
+
+    alert(
+      `Share link copied to clipboard!\n\n${data.shareUrl}`
+    );
+
+  } catch (err) {
+
+    console.error(err);
+
+    alert(
+      "Failed to share report."
+    );
+
+  }
+
+}

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const PORT = process.env.PORT || 3002;
 const API_KEY = process.env.API_KEY;
 const BASE_RETRY_DELAY_MS = 250;
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+const sharedReports = {};
 
 function toPositiveInteger(value, fallback) {
   const parsed = Number(value);
@@ -587,6 +588,57 @@ function createApp(options = {}) {
       });
     }
   });
+
+
+  // ─────────────────────────────
+// SHARE REPORT ROUTES
+// ─────────────────────────────
+
+// Create shareable report
+app.post("/share", (req, res) => {
+
+  const { url, resultType, threats, riskScore } = req.body;
+
+  if (!url || !resultType) {
+    return res.status(400).json({
+      error: "Missing required report data"
+    });
+  }
+
+  // Generate unique share ID
+  const shareId =
+    Math.random().toString(36).substring(2, 10);
+
+  // Store report temporarily
+  sharedReports[shareId] = {
+    url,
+    resultType,
+    threats: threats || [],
+    riskScore: riskScore || 0,
+    createdAt: new Date().toISOString()
+  };
+
+  return res.json({
+    shareUrl:
+      `http://127.0.0.1:5500/share.html?id=${shareId}`
+  });
+
+});
+
+// Get shared report
+app.get("/share/:id", (req, res) => {
+
+  const report = sharedReports[req.params.id];
+
+  if (!report) {
+    return res.status(404).json({
+      error: "Shared report not found"
+    });
+  }
+
+  return res.json(report);
+
+});
 
   app.use((err, req, res, next) => {
     if (err && err.message === "Not allowed by CORS") {

--- a/share.html
+++ b/share.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+  <title>CyberShield Shared Report</title>
+
+  <style>
+
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background: #0f172a;
+      color: #f8fafc;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      padding: 20px;
+    }
+
+    .card {
+      width: 100%;
+      max-width: 700px;
+      background: #111827;
+      border: 1px solid #1e293b;
+      border-radius: 18px;
+      padding: 32px;
+      box-shadow: 0 0 40px rgba(0,0,0,0.4);
+    }
+
+    h1 {
+      color: #00ffb4;
+      margin-bottom: 10px;
+    }
+
+    .label {
+      color: #94a3b8;
+      margin-top: 20px;
+      font-size: 14px;
+    }
+
+    .value {
+      font-size: 18px;
+      margin-top: 6px;
+      word-break: break-word;
+    }
+
+    .safe {
+      color: #00ffb4;
+      font-weight: bold;
+    }
+
+    .danger {
+      color: #f87171;
+      font-weight: bold;
+    }
+
+    .tag {
+      display: inline-block;
+      padding: 6px 12px;
+      border-radius: 20px;
+      background: #7f1d1d;
+      color: #fecaca;
+      margin: 6px 6px 0 0;
+      font-size: 14px;
+    }
+
+  </style>
+
+</head>
+
+<body>
+
+  <div class="card">
+
+    <h1>🛡️ CyberShield Shared Report</h1>
+
+    <div class="label">Scanned URL</div>
+    <div class="value" id="url"></div>
+
+    <div class="label">Result</div>
+    <div class="value" id="result"></div>
+
+    <div class="label">Risk Score</div>
+    <div class="value" id="risk"></div>
+
+    <div class="label">Threats</div>
+    <div class="value" id="threats"></div>
+
+    <div class="label">Generated At</div>
+    <div class="value" id="created"></div>
+
+  </div>
+
+  <script>
+
+    async function loadReport() {
+
+      const params =
+        new URLSearchParams(window.location.search);
+
+      const id = params.get('id');
+
+      if (!id) {
+        alert("Invalid share link");
+        return;
+      }
+
+      const response =
+        await fetch(`http://localhost:3002/share/${id}`);
+
+      const data = await response.json();
+
+      document.getElementById('url').textContent =
+        data.url;
+
+      const resultEl =
+        document.getElementById('result');
+
+      resultEl.textContent =
+        data.resultType;
+
+      resultEl.className =
+        data.resultType.includes('Safe')
+          ? 'value safe'
+          : 'value danger';
+
+      document.getElementById('risk').textContent =
+        data.riskScore + "/100";
+
+      const threatsEl =
+        document.getElementById('threats');
+
+      if (data.threats.length === 0) {
+
+        threatsEl.innerHTML =
+          '<span class="safe">No threats detected</span>';
+
+      } else {
+
+        threatsEl.innerHTML =
+          data.threats
+            .map(t => `<span class="tag">${t}</span>`)
+            .join('');
+
+      }
+
+      document.getElementById('created').textContent =
+        new Date(data.createdAt).toLocaleString();
+
+    }
+
+    loadReport();
+
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Description

This PR introduces a **shareable scan report system** for CyberShield, allowing users to generate public links for scanned URL reports and share them externally.

Previously, scan results could only be viewed within the application. With this update, users can now securely share summarized scan reports with teammates, communities, or security teams through a dedicated public report page.

---

## ✨ Features Added

### 🔗 Share Report Button

* Added a new **“Share Report”** button in the scan result section.
* Allows users to instantly generate a public shareable report link.

### 🌐 Public Share Page

* Added a new `share.html` page for displaying public scan summaries.
* Shared reports display:

  * Scanned URL
  * Scan result status
  * Risk score
  * Threat indicators
  * Timestamp

### ⚙️ Backend Share API

Implemented lightweight backend endpoints for temporary report sharing:

* `POST /share`

  * Generates a unique shareable report link
* `GET /share/:id`

  * Retrieves shared report data

### 📋 Clipboard Integration

* Generated share links are automatically copied to the clipboard for easier sharing.

---

## 🛠️ Technical Details

* Implemented temporary in-memory report storage for lightweight sharing support.
* Maintained compatibility with the existing vanilla JavaScript architecture.
* Existing scanning functionality remains unchanged.

---

## 📸 Screenshots

### 1. Before Changes


<img width="1541" height="876" alt="Screenshot 2026-06-11 010134" src="https://github.com/user-attachments/assets/e9b600e1-8812-4789-9ebf-98ee083ae223" />


### 2. After Changes
<img width="1528" height="893" alt="Screenshot 2026-06-11 012503" src="https://github.com/user-attachments/assets/e94dc3c8-2965-440e-a226-1dc13f20237a" />

<img width="1301" height="917" alt="Screenshot 2026-06-11 012708" src="https://github.com/user-attachments/assets/40071094-3496-49fa-9061-acb798884c79" />

---

## ✅ Result

Users can now:

```text
Scan URL → Generate Share Link → Open Public Report → Share Anywhere
```

This improves collaboration, awareness, and accessibility of scan results across teams and communities.
