### PR TITLE
feat: add domain reputation checker with RDAP lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,37 @@
           <div class="section-tag">The Team</div>
 
           <h2 class="team-title">
+<<<<<<< HEAD
           
+=======
+            Meet the builders
+          </h2>
+
+          <p class="team-sub">
+            The people who made CyberShield possible
+          </p>
+
+        </div>
+
+        <!-- Toggle Button -->
+        <button type="button" class="team-toggle" id="teamToggle" onclick="toggleTeam()" aria-label="Show team members"
+          aria-expanded="false" aria-controls="teamGridWrap">
+
+          <svg aria-hidden="true" id="toggleIcon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="2.2">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+
+        </button>
+
+        <!-- Team Grid -->
+        <div class="team-grid-wrap" id="teamGridWrap">
+          <div class="team-grid" id="teamGrid"></div>
+        </div>
+
+      </div>
+
+>>>>>>> 43e5810 (feat: improve accessibility - ARIA labels, keyboard nav, screen reader support)
       <!-- Footer -->
       <footer class="main-footer">
 

--- a/index.html
+++ b/index.html
@@ -244,9 +244,6 @@
           <div class="section-tag">The Team</div>
 
           <h2 class="team-title">
-<<<<<<< HEAD
-          
-=======
             Meet the builders
           </h2>
 
@@ -274,7 +271,6 @@
 
       </div>
 
->>>>>>> 43e5810 (feat: improve accessibility - ARIA labels, keyboard nav, screen reader support)
       <!-- Footer -->
       <footer class="main-footer">
 

--- a/script.js
+++ b/script.js
@@ -558,13 +558,8 @@ function showResult(type, title, desc, url, threats) {
   resultEl.focus();
 
   if (riskSectionHtml) {
-<<<<<<< HEAD
     // Append risk section inside result div, after the result card
     resultEl.insertAdjacentHTML('beforeend', riskSectionHtml);
-=======
-    // Append risk section after result card
-    resultEl.querySelector('.result-card').insertAdjacentHTML('beforeend', riskSectionHtml);
->>>>>>> 43e5810 (feat: improve accessibility - ARIA labels, keyboard nav, screen reader support)
 
     setTimeout(() => {
       const bar = document.querySelector('.risk-meter-bar');

--- a/script.js
+++ b/script.js
@@ -558,8 +558,13 @@ function showResult(type, title, desc, url, threats) {
   resultEl.focus();
 
   if (riskSectionHtml) {
+<<<<<<< HEAD
     // Append risk section inside result div, after the result card
     resultEl.insertAdjacentHTML('beforeend', riskSectionHtml);
+=======
+    // Append risk section after result card
+    resultEl.querySelector('.result-card').insertAdjacentHTML('beforeend', riskSectionHtml);
+>>>>>>> 43e5810 (feat: improve accessibility - ARIA labels, keyboard nav, screen reader support)
 
     setTimeout(() => {
       const bar = document.querySelector('.risk-meter-bar');

--- a/script.js
+++ b/script.js
@@ -755,7 +755,7 @@ async function checkSecurity() {
 
       // Show threat-specific tips
       showTips(allThreats);
-
+      showDomainReputation(url);
     } else {
       updateStats('safe');
       const urlObj = new URL(url);
@@ -798,6 +798,7 @@ async function checkSecurity() {
 
       // Show rotating general tip
       showTips([]);
+      showDomainReputation(url);
     }
 
     if (data.typosquatting) {
@@ -880,7 +881,92 @@ async function downloadPDF() {
   pdf.addImage(imgData, 'PNG', 0, 20, pageWidth, imgHeight);
   pdf.save('cybershield-report.pdf');
 }
+// ─────────────────────────────
+// DOMAIN REPUTATION
+// ─────────────────────────────
 
+async function showDomainReputation(url) {
+  const resultEl = document.getElementById('result');
+
+  // Remove existing domain card
+  const existing = resultEl.querySelector('.domain-card');
+  if (existing) existing.remove();
+
+  // Placeholder while loading
+  const placeholder = document.createElement('div');
+  placeholder.className = 'domain-card loading-domain';
+  placeholder.innerHTML = `<div class="domain-loading">🔍 Looking up domain info...</div>`;
+  resultEl.insertAdjacentElement('beforeend', placeholder);
+
+  try {
+    const apiHost = (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
+      ? 'http://localhost:3000'
+      : 'https://cybershield-sxz0.onrender.com';
+
+    const response = await fetch(`${apiHost}/domain-info?domain=${encodeURIComponent(url)}`);
+    const data = await response.json();
+
+    if (data.error) throw new Error(data.error);
+
+    const trustColor = data.trustScore >= 70 ? '#00ffb4' : data.trustScore >= 40 ? '#fbbf24' : '#f87171';
+    const trustLabel = data.trustScore >= 70 ? 'Trusted' : data.trustScore >= 40 ? 'Moderate' : 'Low Trust';
+
+    const formatDate = (d) => d ? new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : 'N/A';
+
+    placeholder.outerHTML = `
+      <div class="domain-card" role="region" aria-label="Domain Reputation">
+        <div class="domain-header">
+          <span class="domain-header-icon" aria-hidden="true">🌐</span>
+          <span class="domain-header-title">Domain Reputation</span>
+          <span class="domain-trust-badge" style="color: ${trustColor}; border-color: ${trustColor};">
+            ${trustLabel} · ${data.trustScore}/100
+          </span>
+        </div>
+        <div class="domain-grid">
+          <div class="domain-stat">
+            <div class="domain-stat-label">Domain</div>
+            <div class="domain-stat-value">${data.domain}</div>
+          </div>
+          <div class="domain-stat">
+            <div class="domain-stat-label">Age</div>
+            <div class="domain-stat-value">${data.ageYears !== null ? data.ageYears + ' years' : 'N/A'}</div>
+          </div>
+          <div class="domain-stat">
+            <div class="domain-stat-label">Registered</div>
+            <div class="domain-stat-value">${formatDate(data.registered)}</div>
+          </div>
+          <div class="domain-stat">
+            <div class="domain-stat-label">Expires</div>
+            <div class="domain-stat-value">${formatDate(data.expiry)}</div>
+          </div>
+          <div class="domain-stat">
+            <div class="domain-stat-label">Registrar</div>
+            <div class="domain-stat-value">${data.registrar || 'N/A'}</div>
+          </div>
+          <div class="domain-stat">
+            <div class="domain-stat-label">Nameservers</div>
+            <div class="domain-stat-value">${data.nameservers.length ? data.nameservers.join(', ') : 'N/A'}</div>
+          </div>
+        </div>
+        ${data.status.length ? `
+        <div class="domain-status">
+          ${data.status.map(s => `<span class="domain-status-tag">${s}</span>`).join('')}
+        </div>` : ''}
+      </div>
+    `;
+
+  } catch (err) {
+    placeholder.outerHTML = `
+      <div class="domain-card domain-error" role="region" aria-label="Domain Reputation">
+        <div class="domain-header">
+          <span aria-hidden="true">🌐</span>
+          <span class="domain-header-title">Domain Reputation</span>
+        </div>
+        <p class="domain-error-msg">Could not fetch domain info: ${err.message}</p>
+      </div>
+    `;
+  }
+}
 // ─────────────────────────────
 // THEME TOGGLE
 // ─────────────────────────────

--- a/server.js
+++ b/server.js
@@ -587,7 +587,92 @@ function createApp(options = {}) {
       });
     }
   });
+  app.get("/domain-info", async (req, res) => {
+  const { domain } = req.query;
 
+  if (!domain || typeof domain !== "string") {
+    return res.status(400).json({ error: "No domain provided" });
+  }
+
+  // Extract clean hostname
+  let hostname;
+  try {
+    hostname = new URL(domain.startsWith("http") ? domain : "https://" + domain).hostname;
+  } catch {
+    return res.status(400).json({ error: "Invalid domain" });
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 6000);
+
+    const response = await fetchImpl(
+      `https://rdap.org/domain/${hostname}`,
+      { signal: controller.signal }
+    );
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      return res.status(502).json({ error: "RDAP lookup failed", detail: response.status });
+    }
+
+    const data = await response.json();
+
+    // Parse registration and expiry dates
+    const events = data.events || [];
+    const getEvent = (type) => events.find(e => e.eventAction === type)?.eventDate || null;
+
+    const registered = getEvent("registration");
+    const expiry = getEvent("expiration");
+    const updated = getEvent("last changed");
+
+    // Calculate domain age in years
+    let ageYears = null;
+    if (registered) {
+      const ms = Date.now() - new Date(registered).getTime();
+      ageYears = (ms / (1000 * 60 * 60 * 24 * 365.25)).toFixed(1);
+    }
+
+    // Extract registrar
+    const registrar = data.entities
+      ?.find(e => e.roles?.includes("registrar"))
+      ?.vcardArray?.[1]
+      ?.find(f => f[0] === "fn")?.[3] || null;
+
+    // Extract nameservers
+    const nameservers = (data.nameservers || []).map(ns => ns.ldhName).slice(0, 4);
+
+    // Trust score — simple heuristic
+    let trustScore = 50;
+    if (ageYears !== null) {
+      if (ageYears > 5) trustScore += 30;
+      else if (ageYears > 2) trustScore += 15;
+      else if (ageYears < 0.5) trustScore -= 20;
+    }
+    if (nameservers.length >= 2) trustScore += 10;
+    if (expiry) {
+      const daysToExpiry = (new Date(expiry) - Date.now()) / (1000 * 60 * 60 * 24);
+      if (daysToExpiry < 30) trustScore -= 20;
+    }
+    trustScore = Math.min(100, Math.max(0, trustScore));
+
+    return res.json({
+      domain: hostname,
+      registered,
+      expiry,
+      updated,
+      ageYears,
+      registrar,
+      nameservers,
+      trustScore,
+      status: data.status || []
+    });
+
+  } catch (err) {
+    console.error("[DOMAIN-INFO ERROR]", err.message);
+    return res.status(500).json({ error: "Domain lookup failed", detail: sanitizeErrorDetail(err.message, "Lookup failed") });
+  }
+});
   app.use((err, req, res, next) => {
     if (err && err.message === "Not allowed by CORS") {
       return res.status(403).json({ error: "CORS origin denied" });

--- a/style.css
+++ b/style.css
@@ -1310,7 +1310,6 @@ input[type="text"].input-error {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
-<<<<<<< HEAD
 }
 /* ── Security Tips ── */
 .tips-card {
@@ -1423,11 +1422,7 @@ input[type="text"].input-error {
 .tips-refresh-btn:hover {
   background: rgba(0,255,180,0.15);
 }
-<<<<<<< HEAD
-=======
-}
->>>>>>> 43e5810 (feat: improve accessibility - ARIA labels, keyboard nav, screen reader support)
-=======
+
 
 /* ── Domain Reputation ── */
 .domain-card {
@@ -1521,4 +1516,3 @@ input[type="text"].input-error {
   color: #64748b;
   margin: 0;
 }
->>>>>>> 0d56120 (feat: add domain reputation checker with RDAP lookup)

--- a/style.css
+++ b/style.css
@@ -1310,6 +1310,7 @@ input[type="text"].input-error {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+<<<<<<< HEAD
 }
 /* ── Security Tips ── */
 .tips-card {
@@ -1422,3 +1423,6 @@ input[type="text"].input-error {
 .tips-refresh-btn:hover {
   background: rgba(0,255,180,0.15);
 }
+=======
+}
+>>>>>>> 43e5810 (feat: improve accessibility - ARIA labels, keyboard nav, screen reader support)

--- a/style.css
+++ b/style.css
@@ -1423,6 +1423,102 @@ input[type="text"].input-error {
 .tips-refresh-btn:hover {
   background: rgba(0,255,180,0.15);
 }
+<<<<<<< HEAD
 =======
 }
 >>>>>>> 43e5810 (feat: improve accessibility - ARIA labels, keyboard nav, screen reader support)
+=======
+
+/* ── Domain Reputation ── */
+.domain-card {
+  margin-top: 16px;
+  border-radius: 14px;
+  padding: 20px 24px;
+  background: var(--card-bg, #1e293b);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-left: 4px solid #818cf8;
+}
+
+.domain-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.domain-header-icon {
+  font-size: 20px;
+}
+
+.domain-header-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-primary, #f1f5f9);
+  flex: 1;
+}
+
+.domain-trust-badge {
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid;
+  padding: 3px 10px;
+  border-radius: 20px;
+}
+
+.domain-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.domain-stat {
+  background: rgba(255,255,255,0.04);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.domain-stat-label {
+  font-size: 11px;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+
+.domain-stat-value {
+  font-size: 13px;
+  color: var(--text-primary, #f1f5f9);
+  font-weight: 500;
+  word-break: break-all;
+}
+
+.domain-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.domain-status-tag {
+  font-size: 11px;
+  background: rgba(129,140,248,0.1);
+  color: #818cf8;
+  padding: 3px 10px;
+  border-radius: 20px;
+  border: 1px solid rgba(129,140,248,0.2);
+}
+
+.domain-loading {
+  font-size: 13px;
+  color: #64748b;
+  padding: 8px 0;
+}
+
+.domain-error-msg {
+  font-size: 13px;
+  color: #64748b;
+  margin: 0;
+}
+>>>>>>> 0d56120 (feat: add domain reputation checker with RDAP lookup)


### PR DESCRIPTION
Closes #126

## What's Changed

### `server.js`
- Added new `GET /domain-info` endpoint that accepts a `domain` query parameter
- Calls the free RDAP protocol (`rdap.org`) — no API key required
- Parses and returns: domain name, registration date, expiry date, last updated, domain age in years, registrar, nameservers, and status codes
- Calculates a trust score (0–100) based on domain age, nameserver count, and expiry proximity
- 6 second timeout with proper AbortController handling
- Sanitizes error details in production

### `script.js`
- Added `showDomainReputation(url)` — async function that calls `/domain-info` and renders a domain card
- Shows a loading placeholder while the RDAP lookup is in progress
- Displays: domain, age, registration date, expiry date, registrar, nameservers, status tags
- Trust badge color: green (≥70), yellow (40–69), red (<40)
- Called after every safe and danger scan result
- Existing domain card is removed and re-rendered on each new scan

### `style.css`
- `.domain-card` — card with purple left border
- `.domain-header` / `.domain-trust-badge` — header with colored trust label
- `.domain-grid` — responsive grid for domain stats
- `.domain-stat` / `.domain-stat-label` / `.domain-stat-value` — individual stat cells
- `.domain-status-tag` — pill badges for domain status codes
- `.domain-loading` / `.domain-error-msg` — loading and error states

## Behavior
- After every scan (safe or danger), domain info is fetched in parallel and displayed below the result
- Trust score is a heuristic: older domains with stable nameservers score higher
- If RDAP lookup fails, a graceful error message is shown instead of breaking the UI