### PR TITLE
docs: add missing npm install step to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,17 @@
 git clone https://github.com/mrinalray/Cybershield_URL.git
 cd Cybershield_URL
 
-# 2. Configure environment variables
+# 2. Install dependencies
+npm install
+
+# 3. Configure environment variables
 cp .env.example .env
 # Open .env and fill in API_KEY and GEMINI_API_KEY
 
-# 3. Start the backend
+# 4. Start the backend
 node server.js
 
-# 4. Open frontend
+# 5. Open frontend
 # Open index.html in your browser
 ```
 


### PR DESCRIPTION
Summary
Added the missing npm install step to the Setup & Installation workflow in the README.md.

Closes #173

Why it is needed: The current documentation guides developers to clone the repository and immediately execute node server.js after configuration. This causes an immediate runtime crash because the required Node.js package dependencies haven't been installed yet. Adding npm install ensures a flawless local setup experience.

Testing
Verified that the Markdown syntax highlights accurately and the step numbering flows logically.

Checklist
[x] I have tested the change locally.

[x] I have updated documentation if needed.